### PR TITLE
Fix dropzoneText prop to properly set state

### DIFF
--- a/src/DropzoneArea.js
+++ b/src/DropzoneArea.js
@@ -62,6 +62,7 @@ class DropzoneArea extends Component{
             openSnackBar: false,
             snackbarMessage: '',
             snackbarVariant: 'success'
+            dropzoneText: props.dropzoneText
         }
     }
     componentWillUnmount(){


### PR DESCRIPTION
Fixes an issue where dropzoneText does not get set by props.
Resolves: https://github.com/Yuvaleros/material-ui-dropzone/issues/42